### PR TITLE
Fixed error from null GENERATION_EXPRESSION

### DIFF
--- a/main.go
+++ b/main.go
@@ -255,7 +255,7 @@ func main() {
 				panic(err)
 			}
 			if ok {
-				columnInfoCols += ",`GENERATION_EXPRESSION`"
+				columnInfoCols += ",IFNULL(`GENERATION_EXPRESSION`,'')as`GENERATION_EXPRESSION`"
 			}
 
 			// in this query we're simply getting all the details about our column names


### PR DESCRIPTION
This was resulting in a panic in our environment due to the original query returning null's.