### PR TITLE
Add release workflow and version update banner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          distribution: goreleaser
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,9 @@ builds:
       - linux
       - windows
       - darwin
+    ldflags:
+      - "-s -w"
+      - "-X main.version={{ .Version }}"
 
 archives:
   - formats: [tar.gz]


### PR DESCRIPTION
## Summary
- add a release workflow that runs GoReleaser when a GitHub release publishes
- inject the release tag into binaries via GoReleaser ldflags
- surface an orange update warning by piggybacking on go list metadata and Go's module proxy
- compare versions with golang.org/x/mod/semver so prereleases still trigger alerts

## Testing
- go test ./...
- go install -ldflags "-X main.version=v1.2.0" .
- /Users/brianleishman/go/bin/swoof -r 1000 -t 4 rds-prod2 localhost orderstatuses