### PR TITLE
Anchor source and dest pools to UTC via DSN time_zone param

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/Ompluscator/dynamic-struct v1.3.0
-	github.com/StirlingMarketingGroup/cool-mysql v0.0.23
+	github.com/StirlingMarketingGroup/cool-mysql v0.0.24
 	github.com/cenkalti/backoff/v5 v5.0.1
 	github.com/fatih/color v1.19.0
 	github.com/go-sql-driver/mysql v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/Ompluscator/dynamic-struct v1.3.0 h1:Ozvw+T2UOmV/2J2/L7tPZxrypKen3CGSBwmWj8pwC4Q=
 github.com/Ompluscator/dynamic-struct v1.3.0/go.mod h1:01g22H1GC9IFcrpQ4JQBkzynp8RoT0wmUMx/OvXNnw8=
-github.com/StirlingMarketingGroup/cool-mysql v0.0.23 h1:3lWVPZZRU2fQNlHAjaGt7K0C+JW6cIAXhajNN9nrcF4=
-github.com/StirlingMarketingGroup/cool-mysql v0.0.23/go.mod h1:b2ccpV5BGxtE6nNdxVCYURNtLBdC7blJKh8KSK80syE=
+github.com/StirlingMarketingGroup/cool-mysql v0.0.24 h1:hVC3o+nK7iRtzGD7NrbsKiFTPu0yRFKClZaZgoZyVlo=
+github.com/StirlingMarketingGroup/cool-mysql v0.0.24/go.mod h1:b2ccpV5BGxtE6nNdxVCYURNtLBdC7blJKh8KSK80syE=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=

--- a/main.go
+++ b/main.go
@@ -234,6 +234,15 @@ func main() {
 		}
 	}
 
+	// Anchor the source session to UTC so SHOW CREATE TABLE emits timestamp
+	// defaults (e.g. TIMESTAMP's 2038-01-19 03:14:07.999999 max) in UTC rather
+	// than rendered into whatever tz the server defaulted to.
+	sourceDSN, err := ensureUTCSession(sourceDSN)
+	if err != nil {
+		slog.Error("failed to apply UTC session tz to source DSN", "error", err)
+		os.Exit(1)
+	}
+
 	// source connection is the first argument
 	// this is where our rows are coming from
 	src, err := mysql.NewFromDSN(sourceDSN, sourceDSN)
@@ -382,6 +391,15 @@ func main() {
 				os.Exit(1)
 			}
 		} else {
+			// Anchor every dest pool conn to UTC, matching the source. Without
+			// this a non-UTC dest session reinterprets the SHOW CREATE TABLE
+			// output from the source, shifting boundary timestamp defaults past
+			// the 32-bit seconds range and 1067'ing on CREATE.
+			destDSN, err = ensureUTCSession(destDSN)
+			if err != nil {
+				slog.Error("failed to apply UTC session tz to destination DSN", "error", err, "destinationDSN", friendlyName)
+				os.Exit(1)
+			}
 			db, err = mysql.NewFromDSN(destDSN, destDSN)
 			if err != nil {
 				slog.Error("failed to create destination connection", "error", err, "destinationDSN", destDSN)

--- a/util.go
+++ b/util.go
@@ -15,6 +15,30 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ensureUTCSession injects time_zone='+00:00' into the DSN's params if the
+// user hasn't set one explicitly. go-sql-driver treats unknown DSN params as
+// session system variables and runs the corresponding SET on every new
+// connection its pool opens, so every conn comes up anchored to UTC. Without
+// this, schema replay breaks against servers whose default session tz isn't
+// UTC: SHOW CREATE TABLE emits timestamp defaults rendered in the source
+// session tz, the dest parses them in its own session tz, and the round-trip
+// shifts boundary values (e.g. TIMESTAMP(6)'s max 2038-01-19 03:14:07.999999)
+// past the signed-32-bit seconds range, 1067'ing the CREATE.
+func ensureUTCSession(dsn string) (string, error) {
+	cfg, err := mysqldriver.ParseDSN(dsn)
+	if err != nil {
+		return "", fmt.Errorf("parse DSN: %w", err)
+	}
+	if _, ok := cfg.Params["time_zone"]; ok {
+		return dsn, nil
+	}
+	if cfg.Params == nil {
+		cfg.Params = make(map[string]string)
+	}
+	cfg.Params["time_zone"] = "'+00:00'"
+	return cfg.FormatDSN(), nil
+}
+
 // formatShort renders counts the way dashboards do: under 1000 unchanged,
 // otherwise one decimal plus K / M / B / T. Hand-rolled instead of fmt.Sprintf
 // because the progress-bar decorators call this on every repaint for every

--- a/util.go
+++ b/util.go
@@ -16,14 +16,18 @@ import (
 )
 
 // ensureUTCSession injects time_zone='+00:00' into the DSN's params if the
-// user hasn't set one explicitly. go-sql-driver treats unknown DSN params as
-// session system variables and runs the corresponding SET on every new
-// connection its pool opens, so every conn comes up anchored to UTC. Without
-// this, schema replay breaks against servers whose default session tz isn't
-// UTC: SHOW CREATE TABLE emits timestamp defaults rendered in the source
-// session tz, the dest parses them in its own session tz, and the round-trip
-// shifts boundary values (e.g. TIMESTAMP(6)'s max 2038-01-19 03:14:07.999999)
-// past the signed-32-bit seconds range, 1067'ing the CREATE.
+// user hasn't set one explicitly, so every conn the pool opens comes up with
+// its session tz anchored to UTC (go-sql-driver runs SET on unknown DSN
+// params as part of each new conn's init).
+//
+// Both sides of a swoof run must agree on session tz or schema replay breaks.
+// MySQL stores TIMESTAMP defaults as UTC internally, SHOW CREATE TABLE
+// renders them in the source's session tz, and the destination parses that
+// literal in its own session tz before converting back to UTC for storage.
+// When the two tzs differ, the round-trip shifts boundary values — notably
+// TIMESTAMP(6)'s 2038-01-19 03:14:07.999999 max — past the signed-32-bit
+// seconds range, and strict MySQL rejects the CREATE with ER_INVALID_DEFAULT.
+// Anchoring both sides to UTC makes the round-trip identity.
 func ensureUTCSession(dsn string) (string, error) {
 	cfg, err := mysqldriver.ParseDSN(dsn)
 	if err != nil {

--- a/util_test.go
+++ b/util_test.go
@@ -1,6 +1,62 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	mysqldriver "github.com/go-sql-driver/mysql"
+)
+
+func TestEnsureUTCSession(t *testing.T) {
+	cases := []struct {
+		name          string
+		dsn           string
+		wantTimeZone  string
+		wantUnchanged bool // DSN must be byte-for-byte unchanged
+	}{
+		{
+			name:         "injects on DSN with no params",
+			dsn:          "user:pass@tcp(host:3306)/db",
+			wantTimeZone: "'+00:00'",
+		},
+		{
+			name:         "injects alongside existing params",
+			dsn:          "user:pass@tcp(host:3306)/db?parseTime=true",
+			wantTimeZone: "'+00:00'",
+		},
+		{
+			name:          "respects user-supplied time_zone",
+			dsn:           "user:pass@tcp(host:3306)/db?time_zone=%27%2B05%3A30%27",
+			wantTimeZone:  "'+05:30'",
+			wantUnchanged: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ensureUTCSession(c.dsn)
+			if err != nil {
+				t.Fatalf("ensureUTCSession error: %v", err)
+			}
+			if c.wantUnchanged && got != c.dsn {
+				t.Errorf("DSN changed despite existing time_zone: got %q, original %q", got, c.dsn)
+			}
+			cfg, err := mysqldriver.ParseDSN(got)
+			if err != nil {
+				t.Fatalf("result DSN did not parse: %v", err)
+			}
+			if cfg.Params["time_zone"] != c.wantTimeZone {
+				t.Errorf("time_zone = %q, want %q", cfg.Params["time_zone"], c.wantTimeZone)
+			}
+		})
+	}
+
+	t.Run("returns error on bad DSN", func(t *testing.T) {
+		_, err := ensureUTCSession("::not a dsn::")
+		if err == nil || !strings.Contains(err.Error(), "parse DSN") {
+			t.Fatalf("expected parse DSN error, got %v", err)
+		}
+	})
+}
 
 func TestGlobToLike(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Fixes an intermittent `Error 1067 (Invalid default value)` on schema replay against destinations with non-UTC default session `time_zone`. Happens when the source has a TIMESTAMP boundary-default like `'2038-01-19 03:14:07.999999'` and source/dest session tzs differ.

Root cause: MySQL stores TIMESTAMP defaults as UTC but `SHOW CREATE TABLE` renders them in the session's `time_zone`. Source's render + dest's parse + storage round-trip through different tzs shifts the literal past the signed-32-bit seconds boundary, and newer strict MySQL validators (8.0.x here) reject it.

cool-mysql does attempt to anchor both ends via `SET time_zone = '+00:00'` at pool init, but `SET` is session-scoped and only lands on the one conn the init call grabbed — every subsequent pool conn comes up with the server's default (SYSTEM → EDT on the affected fleet).

Fix: inject `time_zone='+00:00'` as a DSN parameter. go-sql-driver runs the SET on every new conn as part of its connection init, so the whole pool stays anchored to UTC regardless of server default. Applied to source and every MySQL destination; `file:` / `clipboard` dests are skipped because they don't open a real MySQL conn. Respects user-supplied `time_zone` param.

## Test plan

- [x] `go build ./...` / `go vet ./...` / `go test -count=1 -race ./...` clean
- [x] `TestEnsureUTCSession` covers: no-params injection, params-already-set injection, user override preserved, bad DSN error
- [ ] Run against the fleet box that was 1067'ing on `nodeflowinstances` — confirm CREATE TABLE succeeds

## Related

- StirlingMarketingGroup/cool-mysql#152 — the upstream bug this works around (`setSessionTimezone` runs `SET` once on one pool conn, not on every new conn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)