### PR TITLE
Anchor source net_write_timeout and stack-trace retry logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cenkalti/backoff/v5"
 	"github.com/fatih/color"
 	mysqldriver "github.com/go-sql-driver/mysql"
+	"github.com/pkg/errors"
 	"github.com/posener/cmd"
 	"github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
@@ -240,6 +241,14 @@ func main() {
 	sourceDSN, err := ensureUTCSession(sourceDSN)
 	if err != nil {
 		slog.Error("failed to apply UTC session tz to source DSN", "error", err)
+		os.Exit(1)
+	}
+
+	// Stop the source server from killing a streaming read conn when dest
+	// backpressure stalls our TCP read side.
+	sourceDSN, err = ensureLongSourceStream(sourceDSN)
+	if err != nil {
+		slog.Error("failed to apply net_write_timeout to source DSN", "error", err)
 		os.Exit(1)
 	}
 
@@ -564,7 +573,7 @@ func main() {
 				// cursors and metadata queries don't contend on a shared pool.
 				srcTable, err := mysql.NewFromDSN(sourceDSN, sourceDSN)
 				if err != nil {
-					return struct{}{}, fmt.Errorf("open source connection for %q: %w", tableName, err)
+					return struct{}{}, errors.Wrapf(err, "open source connection for %q", tableName)
 				}
 				defer func() {
 					if err := srcTable.Close(); err != nil {
@@ -685,7 +694,7 @@ func main() {
 						for range columns {
 						}
 						<-columnsErrCh
-						return struct{}{}, backoff.Permanent(fmt.Errorf("unknown mysql column type %q for column %q on table %q", c.ColumnType, c.ColumnName, tableName))
+						return struct{}{}, backoff.Permanent(errors.Errorf("unknown mysql column type %q for column %q on table %q", c.ColumnType, c.ColumnName, tableName))
 					}
 
 					rowStruct.AddField(f, v, tag)
@@ -695,7 +704,7 @@ func main() {
 				// Synchronously collect the columns goroutine's result before any
 				// destination DDL runs — this is the fix for the close/ctx race.
 				if err := <-columnsErrCh; err != nil {
-					return struct{}{}, fmt.Errorf("select columns for %q: %w", tableName, err)
+					return struct{}{}, errors.Wrapf(err, "select columns for %q", tableName)
 				}
 
 				structType := reflect.Indirect(reflect.ValueOf(rowStruct.Build().New())).Type()
@@ -713,7 +722,7 @@ func main() {
 						countQ += " where " + *whereClause + " "
 					}
 					if err := srcTable.SelectContext(ctx, &count, countQ, 0); err != nil {
-						return struct{}{}, fmt.Errorf("count rows for %q: %w", tableName, err)
+						return struct{}{}, errors.Wrapf(err, "count rows for %q", tableName)
 					}
 					bar.SetTotal(count, false)
 				}
@@ -728,7 +737,7 @@ func main() {
 						CreateMySQL string `mysql:"Create Table"`
 					}
 					if err := srcTable.SelectContext(ctx, &tableInfo, "show create table`"+tableName+"`", 0); err != nil {
-						return struct{}{}, fmt.Errorf("show create table %q: %w", tableName, err)
+						return struct{}{}, errors.Wrapf(err, "show create table %q", tableName)
 					}
 
 					// FK constraints have globally unique names, so creating the temp table
@@ -751,10 +760,10 @@ func main() {
 					for _, dst := range tableDsts {
 						if !*dryRyn {
 							if err := dst.Exec("drop table if exists`" + tempTableName + "`"); err != nil {
-								return struct{}{}, fmt.Errorf("drop temp table %q: %w", tempTableName, err)
+								return struct{}{}, errors.Wrapf(err, "drop temp table %q", tempTableName)
 							}
 							if err := dst.Exec("CREATE TABLE `" + tempTableName + "`" + createSuffix); err != nil {
-								return struct{}{}, fmt.Errorf("create temp table %q: %w", tempTableName, err)
+								return struct{}{}, errors.Wrapf(err, "create temp table %q", tempTableName)
 							}
 						}
 					}
@@ -847,7 +856,7 @@ func main() {
 							q += " where " + *whereClause + " "
 						}
 						if err := srcTable.SelectContext(ctx, srcChRef.Interface(), q, 0); err != nil {
-							return fmt.Errorf("select rows for %q: %w", tableName, err)
+							return errors.Wrapf(err, "select rows for %q", tableName)
 						}
 						return nil
 					})
@@ -862,7 +871,7 @@ func main() {
 								})
 							}
 							if err := inserter.InsertContext(ctx, insertPrefix, srcChRef.Interface()); err != nil {
-								return fmt.Errorf("insert into %q: %w", tableName, err)
+								return errors.Wrapf(err, "insert into %q", tableName)
 							}
 							return nil
 						})
@@ -925,7 +934,7 @@ func main() {
 									})
 								}
 								if err := inserter.InsertContext(ctx, insertPrefix, dstChRefs[j].Interface()); err != nil {
-									return fmt.Errorf("insert into %q (dest %d): %w", tableName, j, err)
+									return errors.Wrapf(err, "insert into %q (dest %d)", tableName, j)
 								}
 								return nil
 							})
@@ -973,7 +982,8 @@ func main() {
 					"tableName", tableName,
 					"attempt", attempts,
 					"error", err,
-					"chain", formatErrorChain(err))
+					"chain", formatErrorChain(err),
+					"stack", extractErrorStack(err))
 				return v, err
 			}
 
@@ -993,6 +1003,7 @@ func main() {
 				slog.Error("table import failed after retries",
 					"error", inner,
 					"chain", formatErrorChain(inner),
+					"stack", extractErrorStack(inner),
 					"tableName", tableName,
 					"attempts", attempts)
 				os.Exit(1)

--- a/util.go
+++ b/util.go
@@ -43,6 +43,35 @@ func ensureUTCSession(dsn string) (string, error) {
 	return cfg.FormatDSN(), nil
 }
 
+// ensureLongSourceStream injects net_write_timeout=86400 into the DSN's
+// params if the user hasn't set one. Multi-table runs share a single
+// destination pool, which divides write capacity across N concurrent
+// inserters so each table's inserts run at ~1/N the rate they'd reach
+// alone. The source→dest channel fills behind that bottleneck, the
+// source-stream goroutine blocks on channel Send, Go stops reading from
+// the TCP socket, the source server's TCP send buffer fills, and the
+// server's net_write_timeout (60s default) fires and closes the conn.
+// The driver surfaces this as io.ErrUnexpectedEOF, the table import
+// retries from row 0 — expensive on large tables. Single-table runs
+// never trip this: no shared dest, no backpressure.
+//
+// 86400 (24h) leaves real failures to the retry path; it just stops the
+// server from cleaning up a stream that still has work to do.
+func ensureLongSourceStream(dsn string) (string, error) {
+	cfg, err := mysqldriver.ParseDSN(dsn)
+	if err != nil {
+		return "", fmt.Errorf("parse DSN: %w", err)
+	}
+	if _, ok := cfg.Params["net_write_timeout"]; ok {
+		return dsn, nil
+	}
+	if cfg.Params == nil {
+		cfg.Params = make(map[string]string)
+	}
+	cfg.Params["net_write_timeout"] = "86400"
+	return cfg.FormatDSN(), nil
+}
+
 // formatShort renders counts the way dashboards do: under 1000 unchanged,
 // otherwise one decimal plus K / M / B / T. Hand-rolled instead of fmt.Sprintf
 // because the progress-bar decorators call this on every repaint for every
@@ -119,6 +148,28 @@ func formatErrorChain(err error) string {
 		err = next
 	}
 	return b.String()
+}
+
+// extractErrorStack walks the chain for the innermost pkg/errors stack (i.e.
+// the goroutine-local wrap point nearest the raise site) and formats it one
+// frame per line. Returns "" when no layer carries a stack — nothing in the
+// chain had a pkg/errors wrap, so the logger should fall back to just the
+// chain summary.
+func extractErrorStack(err error) string {
+	type stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+	var innermost errors.StackTrace
+	for err != nil {
+		if st, ok := err.(stackTracer); ok {
+			innermost = st.StackTrace()
+		}
+		err = stderrors.Unwrap(err)
+	}
+	if innermost == nil {
+		return ""
+	}
+	return fmt.Sprintf("%+v", innermost)
 }
 
 // isTransientError reports whether err is worth retrying a whole-table import for.

--- a/util_test.go
+++ b/util_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	stderrors "errors"
 	"strings"
 	"testing"
 
 	mysqldriver "github.com/go-sql-driver/mysql"
+	"github.com/pkg/errors"
 )
 
 func TestEnsureUTCSession(t *testing.T) {
@@ -54,6 +56,87 @@ func TestEnsureUTCSession(t *testing.T) {
 		_, err := ensureUTCSession("::not a dsn::")
 		if err == nil || !strings.Contains(err.Error(), "parse DSN") {
 			t.Fatalf("expected parse DSN error, got %v", err)
+		}
+	})
+}
+
+func TestEnsureLongSourceStream(t *testing.T) {
+	cases := []struct {
+		name          string
+		dsn           string
+		wantTimeout   string
+		wantUnchanged bool
+	}{
+		{
+			name:        "injects on DSN with no params",
+			dsn:         "user:pass@tcp(host:3306)/db",
+			wantTimeout: "86400",
+		},
+		{
+			name:        "injects alongside existing params",
+			dsn:         "user:pass@tcp(host:3306)/db?parseTime=true",
+			wantTimeout: "86400",
+		},
+		{
+			name:          "respects user-supplied net_write_timeout",
+			dsn:           "user:pass@tcp(host:3306)/db?net_write_timeout=3600",
+			wantTimeout:   "3600",
+			wantUnchanged: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ensureLongSourceStream(c.dsn)
+			if err != nil {
+				t.Fatalf("ensureLongSourceStream error: %v", err)
+			}
+			if c.wantUnchanged && got != c.dsn {
+				t.Errorf("DSN changed despite existing net_write_timeout: got %q, original %q", got, c.dsn)
+			}
+			cfg, err := mysqldriver.ParseDSN(got)
+			if err != nil {
+				t.Fatalf("result DSN did not parse: %v", err)
+			}
+			if cfg.Params["net_write_timeout"] != c.wantTimeout {
+				t.Errorf("net_write_timeout = %q, want %q", cfg.Params["net_write_timeout"], c.wantTimeout)
+			}
+		})
+	}
+
+	t.Run("returns error on bad DSN", func(t *testing.T) {
+		_, err := ensureLongSourceStream("::not a dsn::")
+		if err == nil || !strings.Contains(err.Error(), "parse DSN") {
+			t.Fatalf("expected parse DSN error, got %v", err)
+		}
+	})
+}
+
+func TestExtractErrorStack(t *testing.T) {
+	t.Run("empty on plain errors", func(t *testing.T) {
+		if got := extractErrorStack(stderrors.New("no stack here")); got != "" {
+			t.Errorf("expected empty stack, got %q", got)
+		}
+	})
+
+	t.Run("empty on nil", func(t *testing.T) {
+		if got := extractErrorStack(nil); got != "" {
+			t.Errorf("expected empty stack, got %q", got)
+		}
+	})
+
+	t.Run("returns innermost frame for wrapped error", func(t *testing.T) {
+		root := stderrors.New("root cause")
+		wrapped := errors.Wrap(root, "inner")
+		outer := errors.Wrap(wrapped, "outer")
+		got := extractErrorStack(outer)
+		if got == "" {
+			t.Fatalf("expected non-empty stack trace")
+		}
+		// StackTrace formatter emits one frame per line; innermost wrap
+		// was on line of errors.Wrap(root, ...) here — we just assert we
+		// got Go frame output.
+		if !strings.Contains(got, "util_test.go") {
+			t.Errorf("stack trace missing test frame: %q", got)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Inject `net_write_timeout=86400` on the source DSN so the source server stops killing streaming reads when destination backpressure stalls our TCP read side. Multi-table runs share a single dest pool; the per-table inserter ends up at ~1/N of dest write capacity, the source→dest channel fills, the source goroutine blocks on Send, Go stops draining the socket, the source server's send buffer fills, and the server's 60s default `net_write_timeout` closes the conn. The driver surfaces that as `io.ErrUnexpectedEOF`, `isTransientError` catches it, and the whole table restarts from row 0. Delivered via go-sql-driver's `handleParams` SET-on-connect mechanism (same pattern as `ensureUTCSession`). Source-only — dest inserts actively push packets so their `net_read_timeout` exposure is negligible.
- Convert the 9 `fmt.Errorf("…%w", err)` wrap points inside `runOnce` to `errors.Wrapf(err, …)` so each wrap captures a Go stack at the goroutine frame where the error was raised (stream select, per-dest insert, fan-out, metadata queries, temp-table DDL).
- Add `extractErrorStack` that walks the chain for the innermost `pkg/errors` `StackTrace()` and formats one frame per line. New `stack` slog field on both the transient-retry warning and the final failed-after-retry error — the next restart surfaces exactly which wrap fired without cross-referencing line numbers by hand.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] Unit tests for `ensureLongSourceStream` (injects on no-params, injects alongside existing params, respects user-supplied `net_write_timeout`, errors on bad DSN)
- [x] Unit tests for `extractErrorStack` (empty on plain errors, empty on nil, returns innermost frame for `errors.Wrap`-wrapped chain)
- [ ] Real multi-table run against a source that previously exhibited the EOF pattern — confirm no more `[mysql] packets.go:58 unexpected EOF` churn and no bar-reset-to-0 resets under concurrent load

🤖 Generated with [Claude Code](https://claude.com/claude-code)