### PR TITLE
Add INSERT row-building benchmark + profile findings for #66

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/Ompluscator/dynamic-struct v1.3.0
-	github.com/StirlingMarketingGroup/cool-mysql v0.0.24
+	github.com/StirlingMarketingGroup/cool-mysql v0.0.25
 	github.com/cenkalti/backoff/v5 v5.0.1
 	github.com/fatih/color v1.19.0
 	github.com/go-sql-driver/mysql v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/Ompluscator/dynamic-struct v1.3.0 h1:Ozvw+T2UOmV/2J2/L7tPZxrypKen3CGSBwmWj8pwC4Q=
 github.com/Ompluscator/dynamic-struct v1.3.0/go.mod h1:01g22H1GC9IFcrpQ4JQBkzynp8RoT0wmUMx/OvXNnw8=
-github.com/StirlingMarketingGroup/cool-mysql v0.0.24 h1:hVC3o+nK7iRtzGD7NrbsKiFTPu0yRFKClZaZgoZyVlo=
-github.com/StirlingMarketingGroup/cool-mysql v0.0.24/go.mod h1:b2ccpV5BGxtE6nNdxVCYURNtLBdC7blJKh8KSK80syE=
+github.com/StirlingMarketingGroup/cool-mysql v0.0.25 h1:CIl9qGmWDtZimJrJXgD5qbH3oKrewI4dIq70ZXl9uJ8=
+github.com/StirlingMarketingGroup/cool-mysql v0.0.25/go.mod h1:b2ccpV5BGxtE6nNdxVCYURNtLBdC7blJKh8KSK80syE=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=

--- a/insert_bench_test.go
+++ b/insert_bench_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"reflect"
@@ -43,7 +42,7 @@ func BenchmarkInsertRowBuild(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		if err := db.I().InsertContext(context.Background(),
+		if err := db.I().InsertContext(b.Context(),
 			benchInsertQuery, rows.Interface()); err != nil {
 			b.Fatal(err)
 		}
@@ -52,7 +51,8 @@ func BenchmarkInsertRowBuild(b *testing.B) {
 
 // BenchmarkInsertRowBuildChan layers the reflect.Chan ping-pong back on, so we
 // can see how much of the in-production cost is scheduler / channel versus
-// the marshal path itself. Same rows, same sink.
+// the marshal path itself. Same rows, same sink — row generation is hoisted
+// out of b.Loop so we measure channel + insert, not makeBenchRow.
 func BenchmarkInsertRowBuildChan(b *testing.B) {
 	structType := buildBenchStructType()
 	rowsPerBatch := 5_000
@@ -62,20 +62,28 @@ func BenchmarkInsertRowBuildChan(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	sliceType := reflect.SliceOf(structType)
+	rows := reflect.MakeSlice(sliceType, rowsPerBatch, rowsPerBatch)
+	for i := 0; i < rowsPerBatch; i++ {
+		rows.Index(i).Set(makeBenchRow(structType, i))
+	}
+
+	chanType := reflect.ChanOf(reflect.BothDir, structType)
+
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for b.Loop() {
-		ch := reflect.MakeChan(reflect.ChanOf(reflect.BothDir, structType), 10_000)
+		ch := reflect.MakeChan(chanType, 10_000)
 
 		go func() {
 			defer ch.Close()
 			for i := 0; i < rowsPerBatch; i++ {
-				ch.Send(makeBenchRow(structType, i))
+				ch.Send(rows.Index(i))
 			}
 		}()
 
-		if err := db.I().InsertContext(context.Background(),
+		if err := db.I().InsertContext(b.Context(),
 			benchInsertQuery, ch.Interface()); err != nil {
 			b.Fatal(err)
 		}
@@ -95,7 +103,7 @@ func buildBenchStructType() reflect.Type {
 	s.AddField("F8", new(uint32), `mysql:"qty"`)
 	s.AddField("F9", new(int8), `mysql:"flags"`)
 	s.AddField("F10", new(json.RawMessage), `mysql:"metadata"`)
-	return reflect.Indirect(reflect.ValueOf(s.Build().New())).Type()
+	return reflect.TypeOf(s.Build().New()).Elem()
 }
 
 func makeBenchRow(t reflect.Type, i int) reflect.Value {

--- a/insert_bench_test.go
+++ b/insert_bench_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"reflect"
+	"strconv"
+	"testing"
+
+	dynamicstruct "github.com/Ompluscator/dynamic-struct"
+	mysql "github.com/StirlingMarketingGroup/cool-mysql"
+)
+
+const benchInsertQuery = "insert into`t`(`id`,`created_at`,`updated_at`,`name`,`email`,`description`,`price`,`qty`,`flags`,`metadata`)"
+
+// BenchmarkInsertRowBuild measures the in-process cost of turning a slice of
+// dynamically-typed rows into INSERT SQL and shipping it to an io.Discard sink.
+// Slice source isolates the row-build / marshal cost from the reflect.Chan
+// scheduler ping-pong we see in production.
+//
+// Column mix approximates a typical business table: mixed int widths, strings
+// (hex-encoded with utf8mb4 wrapper), a JSON column, a decimal passed as
+// mysql.Raw, and a binary blob.
+func BenchmarkInsertRowBuild(b *testing.B) {
+	structType := buildBenchStructType()
+	rowsPerBatch := 5_000
+
+	db, err := mysql.NewWriter(io.Discard)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Pre-build the slice once so the benchmark measures insert cost, not
+	// allocations for the row contents.
+	sliceType := reflect.SliceOf(structType)
+	rows := reflect.MakeSlice(sliceType, rowsPerBatch, rowsPerBatch)
+	for i := 0; i < rowsPerBatch; i++ {
+		rows.Index(i).Set(makeBenchRow(structType, i))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		if err := db.I().InsertContext(context.Background(),
+			benchInsertQuery, rows.Interface()); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkInsertRowBuildChan layers the reflect.Chan ping-pong back on, so we
+// can see how much of the in-production cost is scheduler / channel versus
+// the marshal path itself. Same rows, same sink.
+func BenchmarkInsertRowBuildChan(b *testing.B) {
+	structType := buildBenchStructType()
+	rowsPerBatch := 5_000
+
+	db, err := mysql.NewWriter(io.Discard)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		ch := reflect.MakeChan(reflect.ChanOf(reflect.BothDir, structType), 10_000)
+
+		go func() {
+			defer ch.Close()
+			for i := 0; i < rowsPerBatch; i++ {
+				ch.Send(makeBenchRow(structType, i))
+			}
+		}()
+
+		if err := db.I().InsertContext(context.Background(),
+			benchInsertQuery, ch.Interface()); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func buildBenchStructType() reflect.Type {
+	s := dynamicstruct.NewStruct()
+	// F1..F10, positionally — same shape main.go builds from INFORMATION_SCHEMA.
+	s.AddField("F1", new([]byte), `mysql:"id"`)
+	s.AddField("F2", new(string), `mysql:"created_at"`)
+	s.AddField("F3", new(string), `mysql:"updated_at"`)
+	s.AddField("F4", new(string), `mysql:"name"`)
+	s.AddField("F5", new(string), `mysql:"email"`)
+	s.AddField("F6", new(string), `mysql:"description"`)
+	s.AddField("F7", new(mysql.Raw), `mysql:"price"`)
+	s.AddField("F8", new(uint32), `mysql:"qty"`)
+	s.AddField("F9", new(int8), `mysql:"flags"`)
+	s.AddField("F10", new(json.RawMessage), `mysql:"metadata"`)
+	return reflect.Indirect(reflect.ValueOf(s.Build().New())).Type()
+}
+
+func makeBenchRow(t reflect.Type, i int) reflect.Value {
+	v := reflect.New(t).Elem()
+
+	id := []byte{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24), 0, 0, 0, 1}
+	ts := "2026-04-24 17:27:14.000000"
+	name := "Customer " + strconv.Itoa(i)
+	email := "customer" + strconv.Itoa(i) + "@example.com"
+	desc := "Some reasonably long description text that is representative of a real varchar/text column full of plain ASCII content."
+	price := mysql.Raw("19.99")
+	qty := uint32(i)
+	flags := int8(i % 8)
+	meta := json.RawMessage(`{"source":"bench","idx":` + strconv.Itoa(i) + `}`)
+
+	v.Field(0).Set(reflect.ValueOf(&id))
+	v.Field(1).Set(reflect.ValueOf(&ts))
+	v.Field(2).Set(reflect.ValueOf(&ts))
+	v.Field(3).Set(reflect.ValueOf(&name))
+	v.Field(4).Set(reflect.ValueOf(&email))
+	v.Field(5).Set(reflect.ValueOf(&desc))
+	v.Field(6).Set(reflect.ValueOf(&price))
+	v.Field(7).Set(reflect.ValueOf(&qty))
+	v.Field(8).Set(reflect.ValueOf(&flags))
+	v.Field(9).Set(reflect.ValueOf(&meta))
+
+	return v
+}

--- a/insert_bench_test.go
+++ b/insert_bench_test.go
@@ -34,7 +34,7 @@ func BenchmarkInsertRowBuild(b *testing.B) {
 	// allocations for the row contents.
 	sliceType := reflect.SliceOf(structType)
 	rows := reflect.MakeSlice(sliceType, rowsPerBatch, rowsPerBatch)
-	for i := 0; i < rowsPerBatch; i++ {
+	for i := range rowsPerBatch {
 		rows.Index(i).Set(makeBenchRow(structType, i))
 	}
 
@@ -64,7 +64,7 @@ func BenchmarkInsertRowBuildChan(b *testing.B) {
 
 	sliceType := reflect.SliceOf(structType)
 	rows := reflect.MakeSlice(sliceType, rowsPerBatch, rowsPerBatch)
-	for i := 0; i < rowsPerBatch; i++ {
+	for i := range rowsPerBatch {
 		rows.Index(i).Set(makeBenchRow(structType, i))
 	}
 
@@ -78,7 +78,7 @@ func BenchmarkInsertRowBuildChan(b *testing.B) {
 
 		go func() {
 			defer ch.Close()
-			for i := 0; i < rowsPerBatch; i++ {
+			for i := range rowsPerBatch {
 				ch.Send(rows.Index(i))
 			}
 		}()


### PR DESCRIPTION
## Summary

- Adds `BenchmarkInsertRowBuild` / `BenchmarkInsertRowBuildChan` that exercise swoof's actual INSERT row-building path (dynamic-struct, `Inserter.InsertContext`, `io.Discard` sink) so we can measure in-process CPU with no network, TLS, or MySQL noise.
- Captures the evidence issue #66 asked for: real tests + pprof rather than guessing.
- Bumps cool-mysql to v0.0.25, which contains [cool-mysql#154](https://github.com/StirlingMarketingGroup/cool-mysql/pull/154) — the optimization driven by these findings.

Closes #66.

## Findings (v0.0.24 baseline)

M4 Max, 10-column row mix (`int`, `string`, `[]byte`, `json`, `mysql.Raw`), 5000 rows/op, `NewWriter(io.Discard)` sink:

| Bench | ns/op | allocs/row | B/row |
| --- | --- | --- | --- |
| `BenchmarkInsertRowBuild` (slice source) | 9.10 ms | 29 | 3.7 KB |
| `BenchmarkInsertRowBuildChan` (channel source) | 9.48 ms | 31 | 3.8 KB |

### `pprof -alloc_space` — three call sites dominated

| % of allocs | Site | What |
| --- | --- | --- |
| 37% | `bytes.(*Buffer).String` | `rowBuf.String()` copied each row out of rowBuf only to be written back into insertBuf |
| 19% | `fmt.Appendf` | `_utf8mb4 0x%x collate ...` / `0x%x` — hex-encoding strings and `[]byte` through reflect-driven fmt |
| 10% | `bytes.growSlice` | `insertBuf` started at `len(insertPart)` and regrew as rows appended |

CPU profile mirrored this — `fmt.fmtSbx` + `fmt.doPrintf` were the real work above scheduler noise.

## Measured impact of v0.0.25

`benchstat`, 8 runs each, same machine and benchmark:

```
                      │      v0.0.24      │             v0.0.25                │
                      │      sec/op       │   sec/op     vs base               │
InsertRowBuild-16         9.103m ± 4%       4.473m ± 4%  -50.87% (p=0.000 n=8)
InsertRowBuildChan-16     9.481m ± 5%       5.015m ± 3%  -47.10% (p=0.000 n=8)
geomean                   9.290m            4.736m       -49.02%

                      │      v0.0.24      │              v0.0.25                │
                      │       B/op        │     B/op      vs base               │
InsertRowBuild-16        17.911Mi ± 0%      7.913Mi ± 0%  -55.82% (p=0.000 n=8)
InsertRowBuildChan-16     19.18Mi ± 0%      10.06Mi ± 1%  -47.56% (p=0.000 n=8)
geomean                   18.53Mi           8.920Mi       -51.87%

                      │      v0.0.24      │             v0.0.25                │
                      │     allocs/op     │  allocs/op   vs base               │
InsertRowBuild-16         145.15k ± 0%      50.18k ± 0%  -65.43% (p=0.000 n=8)
InsertRowBuildChan-16     155.16k ± 0%      60.19k ± 0%  -61.21% (p=0.000 n=8)
geomean                   150.1k            54.96k       -63.38%
```

Real reflect.Chan overhead above the slice source is only ~10k allocs per 5000 rows (~2 per row). Remaining delta is handled in follow-up #69 if someone wants to take it further.

## Test plan

- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go test -bench=BenchmarkInsertRowBuild -benchtime=3s -run=^$ -count=8` runs cleanly against v0.0.24 (baseline) and v0.0.25 (patched), numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)